### PR TITLE
Fix CLI converter arguments

### DIFF
--- a/source_convertor/base_convertor.py
+++ b/source_convertor/base_convertor.py
@@ -13,7 +13,7 @@ class BaseSourceConvertor:
         positions_data_path: str,
         history_data_path: str,
         fix_exceed_range: bool,
-        default_dummy_date: str,
+        default_dummy_date: str | None,
         **kwargs,
     ):
         self.positions_data_path = positions_data_path
@@ -29,4 +29,28 @@ class BaseSourceConvertor:
 
     @staticmethod
     def add_argument(parser: argparse.ArgumentParser):
-        pass
+        parser.add_argument(
+            "--positions-data",
+            dest="positions_data_path",
+            type=str,
+            required=True,
+            help="positions csv file",
+        )
+        parser.add_argument(
+            "--history-data",
+            dest="history_data_path",
+            type=str,
+            required=True,
+            help="history csv file",
+        )
+        parser.add_argument(
+            "--fix-exceed-range",
+            action="store_true",
+            help="try to fix quantity mismatch when history range is incomplete",
+        )
+        parser.add_argument(
+            "--default-dummy-date",
+            type=str,
+            default=DEFAULT_DUMMY_DATE,
+            help="date used when filling dummy transactions",
+        )

--- a/source_convertor/schwab_convertor.py
+++ b/source_convertor/schwab_convertor.py
@@ -1,4 +1,5 @@
 import logging
+import argparse
 
 import pandas as pd
 
@@ -41,6 +42,11 @@ def find_position_header_index(
 
 class SchwabConvertor(BaseSourceConvertor):
     loader_name = "schwab"
+
+    @staticmethod
+    def add_argument(parser: argparse.ArgumentParser):
+        """Add Schwab specific arguments to CLI parser."""
+        BaseSourceConvertor.add_argument(parser)
 
     def __init__(
         self,


### PR DESCRIPTION
## Summary
- ensure BaseSourceConvertor exposes command line arguments
- expose same arguments from SchwabConvertor

## Testing
- `python -m pip check`
- `python main.py --convertor-type schwab --output tmp.csv --history-data foo --positions-data bar --fix-exceed-range --default-dummy-date 20200101` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe8c17d8c832fb10c945178b60873